### PR TITLE
Rewriting getting list of latest members

### DIFF
--- a/MVCForum.Website/Controllers/StatsController.cs
+++ b/MVCForum.Website/Controllers/StatsController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Web.Mvc;
 using MVCForum.Domain.Constants;
 using MVCForum.Domain.Interfaces.Services;
@@ -26,14 +27,21 @@ namespace MVCForum.Website.Controllers
         {
             var viewModel = new MainStatsViewModel
                                 {
-                                    LatestMembers = MembershipService.GetLatestUsers(10).ToDictionary(o => o.UserName,
-                                                                                                      o => o.NiceUrl),
                                     MemberCount = MembershipService.MemberCount(),
                                     TopicCount = _topicService.TopicCount(),
                                     PostCount = _postService.PostCount()
                                 };
+
+            viewModel.LatestMembers = new System.Collections.Generic.List<System.Tuple<string, string>>();
+            foreach (var user in MembershipService.GetLatestUsers(10))
+            {
+                if (viewModel.LatestMembers.All(u => u.Item1 != user.UserName))
+                {
+                    viewModel.LatestMembers.Add(new Tuple<string, string>(user.UserName,user.NiceUrl));
+                }
+            }
+
             return PartialView(viewModel);
         }
-
     }
 }

--- a/MVCForum.Website/MVCForum.Website.csproj
+++ b/MVCForum.Website/MVCForum.Website.csproj
@@ -382,9 +382,6 @@
     <Compile Include="Areas\Admin\ViewModels\SettingsViewModels.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="App_Data\LogFile.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="App_Data\lucene_index\NotHere.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/MVCForum.Website/Themes/Dark/Views/Stats/GetMainStats.cshtml
+++ b/MVCForum.Website/Themes/Dark/Views/Stats/GetMainStats.cshtml
@@ -6,7 +6,7 @@
             <li class="latestmemberheading">@Html.LanguageString("Stats.LatestMembers")</li>
             @foreach (var user in Model.LatestMembers)
             {
-                <li><a href="@user.Value">@Html.Raw(user.Key)</a></li>
+                <li><a href="@user.Item2">@Html.Raw(user.Item1)</a></li>
             }
         </ul>
     </div>

--- a/MVCForum.Website/Themes/Jungle/Views/Stats/GetMainStats.cshtml
+++ b/MVCForum.Website/Themes/Jungle/Views/Stats/GetMainStats.cshtml
@@ -6,7 +6,7 @@
             <li class="latestmemberheading">@Html.LanguageString("Stats.LatestMembers")</li>
             @foreach (var user in Model.LatestMembers)
             {
-                <li><a href="@user.Value">@Html.Raw(user.Key)</a></li>
+                <li><a href="@user.Item2">@Html.Raw(user.Item1)</a></li>
             }
         </ul>
     </div>

--- a/MVCForum.Website/Themes/Metro/Views/Stats/GetMainStats.cshtml
+++ b/MVCForum.Website/Themes/Metro/Views/Stats/GetMainStats.cshtml
@@ -6,7 +6,7 @@
             <li class="latestmemberheading">@Html.LanguageString("Stats.LatestMembers")</li>
             @foreach (var user in Model.LatestMembers)
             {
-                <li><a href="@user.Value">@Html.Raw(user.Key)</a></li>
+                <li><a href="@user.Item2">@Html.Raw(user.Item1)</a></li>
             }
         </ul>
     </div>

--- a/MVCForum.Website/Themes/n3o/Views/Stats/GetMainStats.cshtml
+++ b/MVCForum.Website/Themes/n3o/Views/Stats/GetMainStats.cshtml
@@ -6,7 +6,7 @@
             <li class="latestmemberheading">@Html.LanguageString("Stats.LatestMembers")</li>
             @foreach (var user in Model.LatestMembers)
             {
-                <li><a href="@user.Value">@Html.Raw(user.Key)</a></li>
+                <li><a href="@user.Item2">@Html.Raw(user.Item1)</a></li>
             }
         </ul>
     </div>

--- a/MVCForum.Website/ViewModels/StatsViewModels.cs
+++ b/MVCForum.Website/ViewModels/StatsViewModels.cs
@@ -10,6 +10,6 @@ namespace MVCForum.Website.ViewModels
         public int PostCount { get; set; }
         public int TopicCount { get; set; }
         public int MemberCount { get; set; }
-        public Dictionary<string, string> LatestMembers { get; set; }
+        public List<Tuple<string, string>> LatestMembers { get; set; }
     }
 }


### PR DESCRIPTION
Page didn't load, it threw an exception.
Resoin: Last members list was stored in a Dictionary object, in the database we had duplicated user names which caused an exception when trying to add to dictionary: "An item with the same key has already been added."